### PR TITLE
Update to use group id in artifact name when using maven 3 or higher

### DIFF
--- a/org.eclipse.m2e.wtp.feature/feature.xml
+++ b/org.eclipse.m2e.wtp.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.wtp.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.wtp"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.wtp.jaxrs.feature/feature.xml
+++ b/org.eclipse.m2e.wtp.jaxrs.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.wtp.jaxrs.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.wtp.jaxrs"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.wtp.jaxrs/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.wtp.jaxrs/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.wtp.jaxrs;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.1.qualifier
 Bundle-Activator: org.eclipse.m2e.wtp.jaxrs.internal.MavenJaxRsActivator
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.wtp.jpa.feature/feature.xml
+++ b/org.eclipse.m2e.wtp.jpa.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.wtp.jpa.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.wtp.jpa"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.wtp.jpa/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.wtp.jpa/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.wtp.jpa;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.1.qualifier
 Bundle-Activator: org.eclipse.m2e.wtp.jpa.internal.MavenJpaActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.m2e.wtp.jsf.feature/feature.xml
+++ b/org.eclipse.m2e.wtp.jsf.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.wtp.jsf.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.1.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.m2e.wtp.jsf"
       license-feature="org.eclipse.license"

--- a/org.eclipse.m2e.wtp.jsf/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.wtp.jsf/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.m2e.wtp.jsf;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.1.qualifier
 Bundle-Activator: org.eclipse.m2e.wtp.jsf.internal.MavenJSFActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.m2e.wtp.overlay.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.wtp.overlay.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Overlay support for Eclipse WTP - UI
 Bundle-SymbolicName: org.eclipse.m2e.wtp.overlay.ui;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.1.qualifier
 Bundle-Activator: org.eclipse.m2e.wtp.overlay.internal.ui.OverlayUIPluginActivator
 Require-Bundle: org.eclipse.ui,
  org.eclipse.core.runtime,

--- a/org.eclipse.m2e.wtp.overlay/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.wtp.overlay/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Overlay support for Eclipse WTP
 Bundle-SymbolicName: org.eclipse.m2e.wtp.overlay;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.wtp.sdk.feature/feature.xml
+++ b/org.eclipse.m2e.wtp.sdk.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="org.eclipse.m2e.wtp.sdk.feature"
       label="%featureName"
-      version="1.6.0.qualifier"
+      version="1.6.1.qualifier"
       provider-name="%providerName"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">

--- a/org.eclipse.m2e.wtp.target-platform/m2e-wtp-latest.target
+++ b/org.eclipse.m2e.wtp.target-platform/m2e-wtp-latest.target
@@ -40,7 +40,7 @@
 <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.m2e.tests.common" version="0.0.0"/>
-<repository location="https://download.eclipse.org/technology/m2e/snapshots/latest/"/>
+<repository location="https://download.eclipse.org/technology/m2e/releases/latest/"/>
 </location>
 <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.apache.commons.io" version="0.0.0"/>

--- a/org.eclipse.m2e.wtp.target-platform/m2e-wtp-latest.target
+++ b/org.eclipse.m2e.wtp.target-platform/m2e-wtp-latest.target
@@ -40,7 +40,7 @@
 <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.m2e.logback.feature.feature.group" version="0.0.0"/>
 <unit id="org.eclipse.m2e.tests.common" version="0.0.0"/>
-<repository location="https://download.eclipse.org/technology/m2e/releases/latest/"/>
+<repository location="https://download.eclipse.org/technology/m2e/releases/2.3.0/"/>
 </location>
 <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.apache.commons.io" version="0.0.0"/>

--- a/org.eclipse.m2e.wtp.target-platform/m2e-wtp-latest.target
+++ b/org.eclipse.m2e.wtp.target-platform/m2e-wtp-latest.target
@@ -34,7 +34,7 @@
 </location>
 <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.google.gson" version="2.10.1"/>
-<repository location="https://download.eclipse.org/eclipse/updates/4.27-I-builds/"/>
+<repository location="https://download.eclipse.org/eclipse/updates/4.29/"/>
 </location>
 <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>

--- a/org.eclipse.m2e.wtp.target-platform/m2e-wtp-latest.target
+++ b/org.eclipse.m2e.wtp.target-platform/m2e-wtp-latest.target
@@ -45,7 +45,7 @@
 <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.apache.commons.io" version="0.0.0"/>
 <unit id="org.apache.commons.lang3" version="0.0.0"/>
-<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository"/>
+<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20230531010532/repository"/>
 </location>
 <location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.license.feature.group" version="0.0.0"/>

--- a/org.eclipse.m2e.wtp.target-platform/pom.xml
+++ b/org.eclipse.m2e.wtp.target-platform/pom.xml
@@ -28,7 +28,7 @@
       <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>1.3</version>
+          <version>3.4.0</version>
           <executions>
           <execution>
             <id>attach-artifacts</id>

--- a/org.eclipse.m2e.wtp.target-platform/pom.xml
+++ b/org.eclipse.m2e.wtp.target-platform/pom.xml
@@ -15,7 +15,7 @@
   <parent>
 	  <groupId>org.eclipse.m2e.wtp</groupId>
 	  <artifactId>org.eclipse.m2e.wtp.parent</artifactId>
-	  <version>1.6.0-SNAPSHOT</version>
+	  <version>1.6.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.eclipse.m2e.wtp.target-platform</artifactId>

--- a/org.eclipse.m2e.wtp/META-INF/MANIFEST.MF
+++ b/org.eclipse.m2e.wtp/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: Maven Integration for Eclipse WTP
 Bundle-SymbolicName: org.eclipse.m2e.wtp;singleton:=true
-Bundle-Version: 1.6.0.qualifier
+Bundle-Version: 1.6.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.core.resources,

--- a/org.eclipse.m2e.wtp/pom.xml
+++ b/org.eclipse.m2e.wtp/pom.xml
@@ -13,12 +13,12 @@
 	<parent>
 		<groupId>org.eclipse.m2e.wtp</groupId>
 		<artifactId>org.eclipse.m2e.wtp.parent</artifactId>
-		<version>1.6.0-SNAPSHOT</version>
+		<version>1.6.1-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.eclipse.m2e.wtp</artifactId>
 	<packaging>eclipse-plugin</packaging>
-	<version>1.6.0-SNAPSHOT</version>
+	<version>1.6.1-SNAPSHOT</version>
 
 	<name>M2E-WTP :: Core</name>
 </project>

--- a/org.eclipse.m2e.wtp/src/org/eclipse/m2e/wtp/EarPluginConfiguration.java
+++ b/org.eclipse.m2e.wtp/src/org/eclipse/m2e/wtp/EarPluginConfiguration.java
@@ -83,6 +83,7 @@ public class EarPluginConfiguration extends AbstractFilteringSupportMavenPlugin 
   private Set<EarModule>  earModules;
   
   private boolean supportsUseBaseVersion = false;
+  private boolean useGroupIdInWarName = false;
   
   public EarPluginConfiguration(MavenProject mavenProject) {
     if(JEEPackaging.EAR != JEEPackaging.getValue(mavenProject.getPackaging())) {
@@ -95,6 +96,10 @@ public class EarPluginConfiguration extends AbstractFilteringSupportMavenPlugin 
     	VersionRange ear_2_9 = VersionRange.createFromVersionSpec("[2.9,)"); //$NON-NLS-1$
     	if(ear_2_9.containsVersion(new DefaultArtifactVersion(plugin.getVersion()))) {
     		supportsUseBaseVersion = true;
+    	}
+    	VersionRange ear_3_0 = VersionRange.createFromVersionSpec("[3.0,)"); //$NON-NLS-1$
+    	if(ear_3_0.containsVersion(new DefaultArtifactVersion(plugin.getVersion()))) {
+    		useGroupIdInWarName = true;
     	}
     } catch(Exception ex) {
         //Can't happen
@@ -305,6 +310,7 @@ public class EarPluginConfiguration extends AbstractFilteringSupportMavenPlugin 
     }
     if (mapping instanceof AbstractFileNameMapping) {
     	((AbstractFileNameMapping)mapping).setUseBaseVersion(useBaseVersion);
+    	((AbstractFileNameMapping)mapping).setUseGroupIdInWarName(useGroupIdInWarName);
     }
     return mapping;
   }

--- a/org.eclipse.m2e.wtp/src/org/eclipse/m2e/wtp/namemapping/AbstractFileNameMapping.java
+++ b/org.eclipse.m2e.wtp/src/org/eclipse/m2e/wtp/namemapping/AbstractFileNameMapping.java
@@ -22,8 +22,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.eclipse.m2e.wtp.ArtifactHelper;
 
-
-
 /**
  * This class was derived from maven-ear-plugin's org.apache.maven.plugin.ear.output.AbstractFileNameMapping 
  * 
@@ -40,6 +38,7 @@ public abstract class AbstractFileNameMapping
 
 
     private boolean useBaseVersion;
+    private boolean useGroupIdInWarName;
 
 	/**
      * Generates a standard file name for the specified {@link Artifact}.
@@ -58,6 +57,10 @@ public abstract class AbstractFileNameMapping
     	ArtifactHelper.fixArtifactHandler(artifactHandler);
         String extension = artifactHandler.getExtension();
         final StringBuilder buffer = new StringBuilder( 128 );
+        // From 3.0.0 of the maven ear plugin it uses the group id as part of the name
+        if (getUseGroupIdInWarName()) {
+        	buffer.append(a.getGroupId() + "-");
+        }
         buffer.append( a.getArtifactId() );
         if ( addVersion )
         {
@@ -97,6 +100,14 @@ public abstract class AbstractFileNameMapping
      */
     public boolean isUseBaseVersion() {
     	return useBaseVersion;
+    }
+    
+    public void setUseGroupIdInWarName (boolean useGroupIdInWarName) {
+    	this.useGroupIdInWarName = useGroupIdInWarName;
+    }
+    
+    public boolean getUseGroupIdInWarName () {
+    	return useGroupIdInWarName;
     }
     
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
 	<inceptionYear>2008</inceptionYear>
 
 	<properties>
-		<tycho-version>3.0.1</tycho-version>
+		<tycho-version>4.0.3</tycho-version>
 		<tycho.scmUrl>scm:git:http://github.com/eclipse-m2e/m2e-wtp/m2e-wtp.git</tycho.scmUrl>
 		<git.dirtyWorkingTree>warning</git.dirtyWorkingTree>
 		<test.timeout>1800</test.timeout> <!--  30 mins -->
-		<tycho.test.jvmArgs>-Xmx512m</tycho.test.jvmArgs>
+		<tycho.test.jvmArgs>-Xmx512m -DDetectVMInstallationsJob.disabled=true</tycho.test.jvmArgs>
 		<eclipse.target>latest</eclipse.target>
 	</properties>
 
@@ -208,7 +208,7 @@
 				</os>
 			</activation>
 			<properties>
-				<tycho.test.jvmArgs>-Xmx800m -Dosgi.ws=cocoa -XstartOnFirstThread</tycho.test.jvmArgs>
+				<tycho.test.jvmArgs>-Xmx800m -Dosgi.ws=cocoa -DDetectVMInstallationsJob.disabled=true</tycho.test.jvmArgs>
 				<osgi.ws>cocoa</osgi.ws>
 			</properties>
 			<build>
@@ -318,17 +318,4 @@
 			</build>
 		</profile>
 	</profiles>
-
-	<pluginRepositories>
-		<pluginRepository>
-			<id>tycho-snapshots</id>
-			<url>https://repo.eclipse.org/content/repositories/tycho-snapshots/</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>true</enabled>
-			</snapshots>
-		</pluginRepository>
-	</pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>org.eclipse.m2e.wtp</groupId>
 	<artifactId>org.eclipse.m2e.wtp.parent</artifactId>
-	<version>1.6.0-SNAPSHOT</version>
+	<version>1.6.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>M2E-WTP :: Parent</name>
@@ -102,7 +102,7 @@
 						<artifact>
 							<groupId>org.eclipse.m2e.wtp</groupId>
 							<artifactId>org.eclipse.m2e.wtp.target-platform</artifactId>
-							<version>1.6.0-SNAPSHOT</version>
+							<version>1.6.1-SNAPSHOT</version>
 							<classifier>m2e-wtp-latest</classifier>
 						</artifact>
 					</target>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
 		<tycho.scmUrl>scm:git:http://github.com/eclipse-m2e/m2e-wtp/m2e-wtp.git</tycho.scmUrl>
 		<git.dirtyWorkingTree>warning</git.dirtyWorkingTree>
 		<test.timeout>1800</test.timeout> <!--  30 mins -->
-		<tycho.test.jvmArgs>-Xmx512m -DDetectVMInstallationsJob.disabled=true</tycho.test.jvmArgs>
 		<eclipse.target>latest</eclipse.target>
 	</properties>
 
@@ -179,6 +178,16 @@
 				</plugin>
 				<plugin>
 					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>tycho-surefire-plugin</artifactId>
+					<version>${tycho-version}</version>
+					<configuration>
+						<systemProperties>
+							<DetectVMInstallationsJob.disabled>true</DetectVMInstallationsJob.disabled>
+						</systemProperties>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
 					<artifactId>tycho-p2-plugin</artifactId>
 					<version>${tycho-version}</version>
 					<configuration>
@@ -207,10 +216,6 @@
 					<family>mac</family>
 				</os>
 			</activation>
-			<properties>
-				<tycho.test.jvmArgs>-Xmx800m -Dosgi.ws=cocoa -DDetectVMInstallationsJob.disabled=true</tycho.test.jvmArgs>
-				<osgi.ws>cocoa</osgi.ws>
-			</properties>
 			<build>
 				<pluginManagement>
 					<plugins>


### PR DESCRIPTION
When using Maven 3 or higher the output filename for WARS includes the group id. Updated m2e to reflect this change in Maven.